### PR TITLE
Fix warning in check label with char vector

### DIFF
--- a/R/auxchecks.R
+++ b/R/auxchecks.R
@@ -43,6 +43,9 @@ check_WMAT <- function(W, n){
 #' @keywords internal
 check_label <- function(label, n){
   # 1. check if it is a proper vector
+  if (is.character(label)) {
+    label <- factor(label)
+  }
   if ((!is.vector(as.double(label)))||(length(label)!=n)){
     stop("* Supervised Learning : 'label' is required to be a vector of class labels.")
   }


### PR DESCRIPTION
Hi,

Thanks for your work on this package.

When I pass a character vector as a label, I get a warning `NAs introduced by coercion`. However everything seems to work fine.

This warning happens because the internal function `check_label()` coerces to doubles my character vector, before considering coercing it into a factor.

See a minimal example here:
```
Rdimtools:::check_label(c("a", "b", "a", "b"), 4)
```

This pull request fixes this warning by coercing character vectors into factors first

My current workaround is to convert the labels to a factor first (and that is good enough), but I believe this solution is more convenient for other users.

Feel free to merge it or to reject it if you don't think it's a good approach